### PR TITLE
[FIX] Throws HttpNotFoundException in HttpSendAsync when StatusCode is 404

### DIFF
--- a/src/Mvp24Hours.Infrastructure/Exceptions/HttpNotFoundException.cs
+++ b/src/Mvp24Hours.Infrastructure/Exceptions/HttpNotFoundException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Mvp24Hours.Infrastructure.Exceptions
+{
+    public class HttpNotFoundException : Exception
+    {
+
+    }
+}

--- a/src/Mvp24Hours.Infrastructure/Extensions/HttpClientExtensions.cs
+++ b/src/Mvp24Hours.Infrastructure/Extensions/HttpClientExtensions.cs
@@ -5,6 +5,7 @@
 //=====================================================================================
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Helpers;
+using Mvp24Hours.Infrastructure.Exceptions;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
@@ -228,6 +229,10 @@ namespace Mvp24Hours.Extensions
                 TelemetryHelper.Execute(TelemetryLevel.Verbose, "infra-httpclient-sendasync", $"url:{url}|method:{method}");
 
                 var response = await client.SendAsync(request);
+                if(response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new HttpNotFoundException();
+                }
 
                 response.EnsureSuccessStatusCode();
 

--- a/src/Tests/Mvp24Hours.Patterns.Test/HttpClientTest.cs
+++ b/src/Tests/Mvp24Hours.Patterns.Test/HttpClientTest.cs
@@ -5,6 +5,7 @@
 //=====================================================================================
 using Microsoft.Extensions.DependencyInjection;
 using Mvp24Hours.Extensions;
+using Mvp24Hours.Infrastructure.Exceptions;
 using Mvp24Hours.Patterns.Test.Setup;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -51,6 +52,18 @@ namespace Mvp24Hours.Patterns.Test
             var result = await client.HttpGetAsync("users");
             // assert
             Assert.True(result != null);
+        }
+
+        [Fact, Priority(1)]
+        public async Task GetPostsWithNotFoundAsync()
+        {
+            await Assert.ThrowsAsync<HttpNotFoundException>(async () => {
+                // arrange
+                var serviceProvider = startup.InitializeHttp();
+                var factory = serviceProvider.GetService<IHttpClientFactory>();
+                var client = factory.CreateClient("jsonUrl");
+                var result = await client.HttpGetAsync("notFound");
+            });
         }
 
         [Fact, Priority(2)]


### PR DESCRIPTION
Currently, when a StatusCode 404 is returned from a request, an exception of type HttpRequestException is generated due to the EnsureSuccessStatusCode() method (HttpClientExtensions, line 237).

Therefore, the process that called HttpGetAsync receives this exception and cannot identify the reason for the error, as the client does not have access to the request response.

This Pull Request, does a validation before the EnsureSuccessStatusCode() method is executed. In this validation, check if the StatusCode is NotFound, if so we generate a specific exception for HttpNotFoundException, allowing future handling of this exception.

We only treat the 404 verb, as it is the only StatusCode used by the REST standard that is outside the Success Status Code range (200 and 201).

As some applications need to treat Status Code Not Found as a success, we need to have a specific error for that. Otherwise, scenarios where a zip code or CPF was not found will be treated as a generic error.