### PR TITLE
Feature/rollback pipelines

### DIFF
--- a/src/Mvp24Hours.Infrastructure.Pipe/Pipeline.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/Pipeline.cs
@@ -294,6 +294,8 @@ namespace Mvp24Hours.Infrastructure.Pipe
 
             input ??= new PipelineMessage();
 
+            var currentException = default(Exception);
+
             if (!onlyOperationDefault)
             {
                 RunEventInterceptors(input, PipelineInterceptorType.FirstOperation);
@@ -369,6 +371,7 @@ namespace Mvp24Hours.Infrastructure.Pipe
                       TelemetryHelper.Execute(TelemetryLevels.Error, "pipe-pipeline-execute-failure", ex);
                       current.Messages.Add(new MessageResult((ex?.InnerException ?? ex).Message, MessageType.Error));
                       input.AddContent(ex);
+                      currentException = ex;
                   }
                   return current;
               });
@@ -382,6 +385,11 @@ namespace Mvp24Hours.Infrastructure.Pipe
             if (!onlyOperationDefault && input.IsFaulty && ForceRollbackOnFalure)
             {
                 RunRollbackOperations(input);
+            }
+
+            if (!onlyOperationDefault && input.IsFaulty && AllowPropagateException && currentException != null)
+            {
+                throw currentException;
             }
 
             return input;

--- a/src/Mvp24Hours.Infrastructure.Pipe/PipelineBase.cs
+++ b/src/Mvp24Hours.Infrastructure.Pipe/PipelineBase.cs
@@ -14,19 +14,26 @@ namespace Mvp24Hours.Infrastructure.Pipe
     {
         #region [ Ctor ]
         protected PipelineBase()
-            : this(false, false)
+            : this(false, false, false)
         {
         }
 
         protected PipelineBase(bool isBreakOnFail, bool forceRollbackOnFalure)
+            : this(isBreakOnFail, forceRollbackOnFalure, false)
         {
-            this.IsBreakOnFail = isBreakOnFail;
-            this.ForceRollbackOnFalure = forceRollbackOnFalure;
+        }
+
+        protected PipelineBase(bool isBreakOnFail, bool forceRollbackOnFalure, bool allowPropagateException)
+        {
+            IsBreakOnFail = isBreakOnFail;
+            ForceRollbackOnFalure = forceRollbackOnFalure;
+            AllowPropagateException = allowPropagateException; 
         }
         #endregion
 
         #region [ Fields / Properties ]
         protected bool IsBreakOnFail { get; set; }
+        public bool AllowPropagateException { get; set; }
         public bool ForceRollbackOnFalure { get; set; }
         protected IPipelineMessage Message { get; set; }
         #endregion

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
@@ -9,6 +9,7 @@ using Mvp24Hours.Core.Contract.Infrastructure.Pipe;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
@@ -622,6 +623,33 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.False(resultRollbackStep1);
             Assert.False(resultRollbackStep2);
             Assert.False(resultRollbackStep3);
+        }
+
+        [Fact, Priority(14)]
+        public async Task PipelineWithWithAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new PipelineAsync() { AllowPropagateException = true };
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestAsyncStep1>();
+            pipeline.Add<RollbackOperationTestAsyncStep2>();
+            pipeline.Add<RollbackOperationTestAsyncStep3>();
+
+            try
+            {
+                // operations
+                await pipeline.ExecuteAsync();
+            }
+            catch(Exception ex)
+            {
+                exception = ex;
+            }   
+
+            // assert
+            Assert.NotNull(exception);
+            Assert.Equal("My Exception 123", exception.Message);
         }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
@@ -651,5 +651,31 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.NotNull(exception);
             Assert.Equal("My Exception 123", exception.Message);
         }
+
+        [Fact, Priority(15)]
+        public async Task PipelineWithWithoutAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new PipelineAsync(); //AllowPropagateException = false
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestAsyncStep1>();
+            pipeline.Add<RollbackOperationTestAsyncStep2>();
+            pipeline.Add<RollbackOperationTestAsyncStep3>();
+
+            try
+            {
+                // operations
+                await pipeline.ExecuteAsync();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.Null(exception);
+        }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineAsyncTest.cs
@@ -650,6 +650,7 @@ namespace Mvp24Hours.Application.Pipe.Test
             // assert
             Assert.NotNull(exception);
             Assert.Equal("My Exception 123", exception.Message);
+            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
         }
 
         [Fact, Priority(15)]

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -9,7 +9,9 @@ using Mvp24Hours.Core.Contract.Infrastructure.Pipe;
 using Mvp24Hours.Core.Enums.Infrastructure;
 using Mvp24Hours.Extensions;
 using Mvp24Hours.Infrastructure.Pipe;
+using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Priority;
 
@@ -621,6 +623,33 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.False(resultRollbackStep1);
             Assert.False(resultRollbackStep2);
             Assert.False(resultRollbackStep3);
+        }
+
+        [Fact, Priority(14)]
+        public void PipelineWithWithAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new Pipeline() { AllowPropagateException = true };
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestStep1>();
+            pipeline.Add<RollbackOperationTestStep2>();
+            pipeline.Add<RollbackOperationTestStep3>();
+
+            try
+            {
+                // operations
+                pipeline.Execute();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.NotNull(exception);
+            Assert.Equal("My Exception 123", exception.Message);
         }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -651,5 +651,31 @@ namespace Mvp24Hours.Application.Pipe.Test
             Assert.NotNull(exception);
             Assert.Equal("My Exception 123", exception.Message);
         }
+
+        [Fact, Priority(15)]
+        public void PipelineWithWithoutAllowPropagateException()
+        {
+            // arrange
+            var pipeline = new Pipeline(); //AllowPropagateException = false
+            var exception = default(Exception);
+
+            // act
+            pipeline.Add<RollbackOperationTestStep1>();
+            pipeline.Add<RollbackOperationTestStep2>();
+            pipeline.Add<RollbackOperationTestStep3>();
+
+            try
+            {
+                // operations
+                pipeline.Execute();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // assert
+            Assert.Null(exception);
+        }
     }
 }

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/PipelineTest.cs
@@ -650,6 +650,7 @@ namespace Mvp24Hours.Application.Pipe.Test
             // assert
             Assert.NotNull(exception);
             Assert.Equal("My Exception 123", exception.Message);
+            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
         }
 
         [Fact, Priority(15)]

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
@@ -9,7 +9,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override async Task ExecuteAsync(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception("My Exception 123");
+            throw new System.InvalidOperationException("My Exception 123");
         }
 
         public override async Task RollbackAsync(IPipelineMessage input)

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestAsyncStep3.cs
@@ -9,7 +9,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override async Task ExecuteAsync(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception();
+            throw new System.Exception("My Exception 123");
         }
 
         public override async Task RollbackAsync(IPipelineMessage input)

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
@@ -8,7 +8,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override void Execute(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception("My Exception 123");
+            throw new System.InvalidOperationException("My Exception 123");
         }
 
         public override void Rollback(IPipelineMessage input)

--- a/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
+++ b/src/Tests/Mvp24Hours.Application.Pipe.Test/Rollbacks/RollbackOperationTestStep3.cs
@@ -8,7 +8,7 @@ namespace Mvp24Hours.Application.Pipe.Test.Rollbacks
         public override void Execute(IPipelineMessage input)
         {
             input.AddContent("key-test-step3", 3);
-            throw new System.Exception();
+            throw new System.Exception("My Exception 123");
         }
 
         public override void Rollback(IPipelineMessage input)


### PR DESCRIPTION
Adicionando uma propriedade que permite que o pipeline propague a exception para o chamador.

Essa propriedade não impede que o rollback seja acionado e nem outras funções de controle de erro. A exception só será lançada por último após todas as execuções